### PR TITLE
Update jdk jigsaw version to 111 and fix some examples

### DIFF
--- a/07_The_linker/linkModules.sh
+++ b/07_The_linker/linkModules.sh
@@ -7,8 +7,8 @@ rm -f greetings.jmod
 
 echo
 echo "Creating a module (greetings.jmod) from multiple modules / packages / classes with jlink."
-jmod --create --class-path mods/com.greetings:mods/org.astro greetings.jmod
+jmod create --class-path mods/com.greetings:mods/org.astro greetings.jmod
 
 echo
 echo "Enlisting the contents of the module (greetings.jmod)."
-jmod --list greetings.jmod
+jmod list greetings.jmod

--- a/09_JLink/link.sh
+++ b/09_JLink/link.sh
@@ -5,8 +5,6 @@ set -eu
 echo "Removing any existing executable directory"
 rm -rf executable
 
-mkdir executable
-
 echo
 echo "Create an executable version of the com.greetings module"
 jlink --modulepath $JAVA_HOME/jmods:mlib --addmods com.greetings --output executable

--- a/getJigsawJDK.sh
+++ b/getJigsawJDK.sh
@@ -3,15 +3,15 @@
 set -eu
 
 JDK_DESTINATION=$(echo ```pwd```)
-JDK_FOLDER_NAME="jdk1.9.0"
+JDK_FOLDER_NAME="jdk-9"
 JDK_HOME_OS_SPECIFIC="$JDK_DESTINATION/$JDK_FOLDER_NAME"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	JDK_TAR_FILE_NAME="jigsaw-jdk-bin-macosx-x86_64.tar.gz"
+	JDK_TAR_FILE_NAME="jigsaw-jdk-9-ea+111_osx-x64_bin.tar.gz"
 	JDK_FOLDER_NAME="$JDK_FOLDER_NAME.jdk"
 	JDK_HOME_OS_SPECIFIC="$JDK_DESTINATION/$JDK_FOLDER_NAME/Contents/Home"
 else 
-	JDK_TAR_FILE_NAME="jigsaw-jdk-bin-linux-x64.tar.gz"
+	JDK_TAR_FILE_NAME="jigsaw-jdk-9-ea+111_linux-x64_bin.tar.gz"
 fi
 
 JDK_HOME_OS_SPECIFIC_BIN="$JDK_HOME_OS_SPECIFIC/bin"
@@ -21,7 +21,7 @@ function checkIfJigsawJDKIsDownloaded() {
 	echo "Checking if the Jigsaw JDK has already been downloaded..."
 	if [ ! -f "$JDK_TAR_FILE_NAME" ]; then
 		echo "No Jigsaw JDK does not exist, downloading now..."
-		wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -O $JDK_TAR_FILE_NAME http://download.java.net/jigsaw/archive/b80/binaries/$JDK_TAR_FILE_NAME?q=download/jigsaw/archive/b80/binaries/$JDK_TAR_FILE_NAME 
+		wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -O $JDK_TAR_FILE_NAME http://www.java.net/download/java/jigsaw/archive/111/binaries/$JDK_TAR_FILE_NAME 
 	else
 		echo -e "The Jigsaw JDK ($JDK_TAR_FILE_NAME) has already been downloaded."
 	fi


### PR DESCRIPTION
Thanks a lot for this repository, it helped me get started with jigsaw really quickly. :) 

I've encountered some issues related to older version of jdk jigsaw (b80). I've changed it to newest version (111) and fixed some examples. I've commented my changes in the commits.  

I have tested changes on mac osx (el capitan) and on ubuntu docker image. 

One example that still does not work is 08_XModules_Overries:
```
src/java.base/java/util/concurrent/ConcurrentHashMap.java:3: error: ConcurrentHashMap is not abstract and does not override abstract method entrySet() in Map
public class ConcurrentHashMap implements java.util.Map {
```

I can fix it later in another pull request and maybe add some more examples. 

Thanks :)