### PR TITLE
Updated to JDK 9-ea+142 & modified scripts to use latest options format

### DIFF
--- a/01_Greetings/compile.sh
+++ b/01_Greetings/compile.sh
@@ -8,7 +8,7 @@ echo "Creating folder $COM_GREETINGS_FOLDER, if it does not exists."
 mkdir -p $COM_GREETINGS_FOLDER
 
 echo "Compiling modules in $COM_GREETINGS_FOLDER"
-javac -modulepath mods -d $COM_GREETINGS_FOLDER \
+javac --module-path mods -d $COM_GREETINGS_FOLDER \
         src/com.greetings/module-info.java src/com.greetings/com/greetings/Main.java
 
 tree -fl $COM_GREETINGS_FOLDER

--- a/01_Greetings/run.sh
+++ b/01_Greetings/run.sh
@@ -5,4 +5,4 @@ set -eu
 echo 
 echo "Running 'com.greetings.Main' from within the mods folder."
 echo 
-java -modulepath mods -m com.greetings/com.greetings.Main
+java --module-path mods -m com.greetings/com.greetings.Main

--- a/02_GreetingsWorld/compile.sh
+++ b/02_GreetingsWorld/compile.sh
@@ -14,7 +14,7 @@ javac -d $ORG_ASTRO_FOLDER \
 tree -fl $ORG_ASTRO_FOLDER
 
 echo "Compiling modules in $COM_GREETINGS_FOLDER"
-javac -modulepath mods -d $COM_GREETINGS_FOLDER \
+javac --module-path mods -d $COM_GREETINGS_FOLDER \
         src/com.greetings/module-info.java src/com.greetings/com/greetings/Main.java
 
 tree -fl $COM_GREETINGS_FOLDER

--- a/02_GreetingsWorld/run.sh
+++ b/02_GreetingsWorld/run.sh
@@ -6,4 +6,4 @@ echo
 echo "Running 'com.greetings.Main' from within the mods folder."
 echo "Dependent on 'org.astro.World' from within the mods folder."
 echo 
-java -modulepath mods -m com.greetings/com.greetings.Main
+java --module-path mods -m com.greetings/com.greetings.Main

--- a/03_MultiModuleCompilation/multiModCompile.sh
+++ b/03_MultiModuleCompilation/multiModCompile.sh
@@ -8,6 +8,6 @@ mkdir -p $DESTINATION_FOLDER
 
 echo "Compiling modules in $DESTINATION_FOLDER"
 javac -d $DESTINATION_FOLDER \
-	-modulesourcepath src $(find . -name "*.java")
+  --module-source-path src $(find . -name "*.java")
 
 tree -fl $DESTINATION_FOLDER

--- a/03_MultiModuleCompilation/run.sh
+++ b/03_MultiModuleCompilation/run.sh
@@ -6,4 +6,4 @@ echo
 echo "Running 'com.greetings.Main' from within the mods folder."
 echo "Dependent on 'org.astro.World' from within the mods folder."
 echo 
-java -modulepath mods -m com.greetings/com.greetings.Main
+java --module-path mods -m com.greetings/com.greetings.Main

--- a/04_Packaging/compile.sh
+++ b/04_Packaging/compile.sh
@@ -14,7 +14,6 @@ javac -d $ORG_ASTRO_FOLDER \
 tree -fl $ORG_ASTRO_FOLDER
 
 echo "Compiling modules in $COM_GREETINGS_FOLDER"
-javac -modulepath mods -d $COM_GREETINGS_FOLDER \
+javac --module-path mods -d $COM_GREETINGS_FOLDER \
         src/com.greetings/module-info.java src/com.greetings/com/greetings/Main.java
 
-tree -fl $COM_GREETINGS_FOLDER

--- a/04_Packaging/run.sh
+++ b/04_Packaging/run.sh
@@ -6,4 +6,4 @@ echo
 echo "Running 'com.greetings.Main' from within the module (jar) in the mlib folder."
 echo "Dependent on 'org.astro.World' from within the module (jar) in the mlib folder."
 echo 
-java -mp mlib -m com.greetings
+java --module-path mlib --module com.greetings

--- a/05_Missing_exports/compile.sh
+++ b/05_Missing_exports/compile.sh
@@ -14,7 +14,6 @@ javac -d $ORG_ASTRO_FOLDER \
 tree -fl $ORG_ASTRO_FOLDER
 
 echo "Compiling modules in $COM_GREETINGS_FOLDER"
-javac -modulepath mods -d $COM_GREETINGS_FOLDER \
+javac --module-path mods -d $COM_GREETINGS_FOLDER \
         src/com.greetings/module-info.java src/com.greetings/com/greetings/Main.java
 
-tree -fl $COM_GREETINGS_FOLDER

--- a/05_Missing_requires/compile.sh
+++ b/05_Missing_requires/compile.sh
@@ -14,7 +14,6 @@ javac -d $ORG_ASTRO_FOLDER \
 tree -fl $ORG_ASTRO_FOLDER
 
 echo "Compiling modules in $COM_GREETINGS_FOLDER"
-javac -modulepath mods -d $COM_GREETINGS_FOLDER \
+javac --module-path mods -d $COM_GREETINGS_FOLDER \
         src/com.greetings/module-info.java src/com.greetings/com/greetings/Main.java
 
-tree -fl $COM_GREETINGS_FOLDER

--- a/06_Services/multiModCompile.sh
+++ b/06_Services/multiModCompile.sh
@@ -8,10 +8,9 @@ mkdir -p $DESTINATION_FOLDER
 
 echo "Compiling modules in $DESTINATION_FOLDER"
 javac -d $DESTINATION_FOLDER \
-	-modulesourcepath src $(find src -name "*.java")
+  --module-source-path src $(find src -name "*.java")
 
 tree -fl $DESTINATION_FOLDER
 
 #echo "Compiling modules in com.greetings - separately"
-#javac -d mods/com.greetings/ -mp mods $(find src/com.greetings/ -name "*.java")
-
+#javac -d mods/com.greetings/ --module-path mods $(find src/com.greetings/ -name "*.java")

--- a/06_Services/run.sh
+++ b/06_Services/run.sh
@@ -6,4 +6,4 @@ echo
 echo "Running 'com.greetings.Main' from within the mods folder."
 echo "Depends on 'com.socket' & 'com.fastsocket'from within the mods folder."
 echo
-java -modulepath mods -m com.greetings/com.greetings.Main
+java --module-path mods --module com.greetings/com.greetings.Main

--- a/07_The_linker/compile.sh
+++ b/07_The_linker/compile.sh
@@ -14,7 +14,6 @@ javac -d $ORG_ASTRO_FOLDER \
 tree -fl $ORG_ASTRO_FOLDER
 
 echo "Compiling modules in $COM_GREETINGS_FOLDER"
-javac -modulepath mods -d $COM_GREETINGS_FOLDER \
+javac --module-path mods -d $COM_GREETINGS_FOLDER \
         src/com.greetings/module-info.java src/com.greetings/com/greetings/Main.java
 
-tree -fl $COM_GREETINGS_FOLDER

--- a/07_The_linker/run.sh
+++ b/07_The_linker/run.sh
@@ -6,4 +6,4 @@ echo
 echo "Running 'com.greetings.Main' from within the module (jar) in the mlib folder."
 echo "Dependent on 'org.astro.World' from within the module (jar) in the mlib folder."
 echo 
-java -mp mlib -m com.greetings
+java --module-path mlib --module com.greetings

--- a/09_JLink/compile.sh
+++ b/09_JLink/compile.sh
@@ -14,7 +14,7 @@ javac -d $ORG_ASTRO_FOLDER \
 tree -fl $ORG_ASTRO_FOLDER
 
 echo "Compiling modules in $COM_GREETINGS_FOLDER"
-javac -modulepath mods -d $COM_GREETINGS_FOLDER \
+javac --module-path mods -d $COM_GREETINGS_FOLDER \
         src/com.greetings/module-info.java src/com.greetings/com/greetings/Main.java
 
 tree -fl $COM_GREETINGS_FOLDER

--- a/09_JLink/link.sh
+++ b/09_JLink/link.sh
@@ -7,6 +7,6 @@ rm -rf executable
 
 echo
 echo "Create an executable version of the com.greetings module"
-jlink --modulepath $JAVA_HOME/jmods:mlib --addmods com.greetings --output executable
+jlink --module-path $JAVA_HOME/jmods:mlib --add-modules com.greetings --output executable
 
 tree executable

--- a/10_ModulesExportConflict/compile.sh
+++ b/10_ModulesExportConflict/compile.sh
@@ -20,7 +20,7 @@ javac -d $ORG_ASTRO2_FOLDER \
 tree -fl $ORG_ASTRO2_FOLDER
 
 echo "Compiling modules in $COM_GREETINGS_FOLDER"
-javac -modulepath mods -d $COM_GREETINGS_FOLDER \
+javac --module-path mods -d $COM_GREETINGS_FOLDER \
         src/com.greetings/module-info.java src/com.greetings/com/greetings/Main.java
 
 tree -fl $COM_GREETINGS_FOLDER

--- a/10_ModulesExportConflict/run.sh
+++ b/10_ModulesExportConflict/run.sh
@@ -6,4 +6,4 @@ echo
 echo "Running 'com.greetings.Main' from within the mods folder."
 echo "Will fail because 'org.astro' and 'org.astro2' packages are exporting the same module 'org.astro'."
 echo 
-java -modulepath mods -m com.greetings/com.greetings.Main
+java --module-path mods --module com.greetings/com.greetings.Main

--- a/getJigsawJDK.sh
+++ b/getJigsawJDK.sh
@@ -7,11 +7,11 @@ JDK_FOLDER_NAME="jdk-9"
 JDK_HOME_OS_SPECIFIC="$JDK_DESTINATION/$JDK_FOLDER_NAME"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	JDK_TAR_FILE_NAME="jigsaw-jdk-9-ea+111_osx-x64_bin.tar.gz"
+  JDK_TAR_FILE_NAME="jigsaw-jdk-9-ea+142_osx-x64_bin.tar.gz"
 	JDK_FOLDER_NAME="$JDK_FOLDER_NAME.jdk"
 	JDK_HOME_OS_SPECIFIC="$JDK_DESTINATION/$JDK_FOLDER_NAME/Contents/Home"
 else 
-	JDK_TAR_FILE_NAME="jigsaw-jdk-9-ea+111_linux-x64_bin.tar.gz"
+  JDK_TAR_FILE_NAME="jigsaw-jdk-9-ea+142_linux-x64_bin.tar.gz"
 fi
 
 JDK_HOME_OS_SPECIFIC_BIN="$JDK_HOME_OS_SPECIFIC/bin"
@@ -21,8 +21,8 @@ function checkIfJigsawJDKIsDownloaded() {
 	echo "Checking if the Jigsaw JDK has already been downloaded..."
 	if [ ! -f "$JDK_TAR_FILE_NAME" ]; then
 		echo "No Jigsaw JDK does not exist, downloading now..."
-		wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -O $JDK_TAR_FILE_NAME http://www.java.net/download/java/jigsaw/archive/111/binaries/$JDK_TAR_FILE_NAME 
-	else
+    wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -O $JDK_TAR_FILE_NAME http://www.java.net/download/java/jigsaw/archive/142/binaries/$JDK_TAR_FILE_NAME
+  else
 		echo -e "The Jigsaw JDK ($JDK_TAR_FILE_NAME) has already been downloaded."
 	fi
 }


### PR DESCRIPTION
The format of command line options has changes since version Java SE
9-ea+111 use the standard -- and kebab-case naming in Java SE version 9-ea+142

For example:
-modulepath is now --module-path
-modulesourcepath is now --module-source-path
-module is now --module

All compile, multiModCompile, link and run scripts have been updated