### PR TITLE
Generic version download script for JDK

### DIFF
--- a/getJigsawJDK.sh
+++ b/getJigsawJDK.sh
@@ -2,16 +2,24 @@
 
 set -eu
 
+# Update version number as a string when a new binary is available
+JDK_CURRENT_VERSION="142"
+
+# Binary name and download path composed with these values and current version
+JDK_NAME_GENERIC="jigsaw-jdk-9-ea+"
+JDK_NAME_LINUX="_linux-x64_bin.tar.gz"
+JDK_NAME_OSX="_osx-x64_bin.tar.gz"
+
 JDK_DESTINATION=$(echo ```pwd```)
 JDK_FOLDER_NAME="jdk-9"
 JDK_HOME_OS_SPECIFIC="$JDK_DESTINATION/$JDK_FOLDER_NAME"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  JDK_TAR_FILE_NAME="jigsaw-jdk-9-ea+142_osx-x64_bin.tar.gz"
+  JDK_TAR_FILE_NAME=$JDK_NAME_GENERIC$JDK_CURRENT_VERSION$JDK_NAME_OSX
 	JDK_FOLDER_NAME="$JDK_FOLDER_NAME.jdk"
 	JDK_HOME_OS_SPECIFIC="$JDK_DESTINATION/$JDK_FOLDER_NAME/Contents/Home"
-else 
-  JDK_TAR_FILE_NAME="jigsaw-jdk-9-ea+142_linux-x64_bin.tar.gz"
+else
+  JDK_TAR_FILE_NAME=$JDK_NAME_GENERIC$JDK_CURRENT_VERSION$JDK_NAME_LINUX
 fi
 
 JDK_HOME_OS_SPECIFIC_BIN="$JDK_HOME_OS_SPECIFIC/bin"
@@ -21,10 +29,10 @@ function checkIfJigsawJDKIsDownloaded() {
 	echo "Checking if the Jigsaw JDK has already been downloaded..."
 	if [ ! -f "$JDK_TAR_FILE_NAME" ]; then
 		echo "No Jigsaw JDK does not exist, downloading now..."
-    wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -O $JDK_TAR_FILE_NAME http://www.java.net/download/java/jigsaw/archive/142/binaries/$JDK_TAR_FILE_NAME
+    wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -O $JDK_TAR_FILE_NAME http://www.java.net/download/java/jigsaw/archive/$JDK_CURRENT_VERSION/binaries/$JDK_TAR_FILE_NAME
   else
-		echo -e "The Jigsaw JDK ($JDK_TAR_FILE_NAME) has already been downloaded."
-	fi
+    echo -e "The Jigsaw JDK ($JDK_TAR_FILE_NAME) has already been downloaded."
+  fi
 }
 
 


### PR DESCRIPTION
Converted the download script to be generic, so not hard-coded to a specific
binary version.

The following Variables have been created

JDK_CURRENT_VERSION
Used to set the current version number as a string.  This is the only
variable that needs to be updated when a new binary is available.

The name and download path for the binary file are combined in the
JDK_TAR_FILE_NAME variable with the follwing variables and the current
version variable

JDK_NAME_GENERIC="jigsaw-jdk-9-ea+"
JDK_NAME_LINUX="_linux-x64_bin.tar.gz"
JDK_NAME_OSX="_osx-x64_bin.tar.gz"

The wget command has been updated to include the JDK_CURRENT_VERSION
variable in the path for the java.net website.