### PR TITLE
Updating JDK9 Jigsaw links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ should also work there. Happy to received a pull request for it.
 #### Download and install latest version of the JDK 9 EA
 
 - Download JDK 9 EA
-Early Access build of Jigsaw JDK9 is available at [https://jdk9.java.net/jigsaw/](https://jdk9.java.net/jigsaw/). **Alternative site to download JDK 9 EA binaries from http://bit.ly/2oyOAnf (build 166)**.
+Early Access build of Jigsaw JDK9 is available at [http://jdk.java.net/jigsaw/](http://jdk.java.net/jigsaw/). **Alternative site to download JDK 9 EA binaries from http://bit.ly/2oyOAnf (build 166)**.
 
 **Linux and MacOSX users only:** the bash script ```getJigsawJDK.sh``` in the root directory of this repo, helps download the latest Jigsaw JDK from Oracle. Please run this once the repo is cloned. 
 


### PR DESCRIPTION
The old links do not work any more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adoptopenjdk/jdk9-jigsaw/37)
<!-- Reviewable:end -->
