### PR TITLE
Implement concurrent  hashmap interface

### DIFF
--- a/session-1-jigsaw-intro/07_patch_module_option/src/java.base/java/util/concurrent/ConcurrentHashMap.java
+++ b/session-1-jigsaw-intro/07_patch_module_option/src/java.base/java/util/concurrent/ConcurrentHashMap.java
@@ -6,8 +6,22 @@ import java.util.Map;
 import java.util.Set;
 
 public class ConcurrentHashMap<K,V> extends AbstractMap<K,V> implements ConcurrentMap<K,V>, Serializable {
+
 	public static void main(String[] args) {
 		System.out.printf("ConcurrentHashMap");
+	}
+
+	public ConcurrentHashMap() {
+	}
+
+	public ConcurrentHashMap(Map<? extends K, ? extends V> m) {
+	}
+
+	public ConcurrentHashMap(int initialCapacity) {
+	}
+
+	public V put(K key, V value) {
+		throw new RuntimeException("Not implemented <ConcurrentHashMap>");
 	}
 
 	public Set<Map.Entry<K,V>> entrySet() {


### PR DESCRIPTION
Implement the interface for a more significant error:

```

 *** Running  from within the mods folder. ***

Error occurred during initialization of VM
java.lang.NullPointerException
	at java.util.AbstractMap.get(java.base/AbstractMap.java:176)
	at java.util.Properties.getProperty(java.base/Properties.java:1013)
	at java.lang.System.initProperties(java.base/Native Method)
	at java.lang.System.initPhase1(java.base/System.java:1922)
```

The JVM loads system properties into a property objects that uses Concurrent Hashmap as storages, as a result the init returns a null pointer exception. 