### PR TITLE
Fixed Java Home issue: Set Windows System variable JAVA_HOME to e.g. …

### DIFF
--- a/session-2-jlink/01_JLink/link.sh
+++ b/session-2-jlink/01_JLink/link.sh
@@ -25,7 +25,8 @@ echo ""
 echo "${info} *** Create an executable version of the com.greetings module *** ${normal}"
 if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] ; then
     # Windows users: please not that if the below fails due to JAVA_HOME substitution, please hard-code the JAVA_HOME path into the script
-    jlink --module-path "${JAVA_HOME}\jmods;mlib" \
+    echo "'${JAVA_HOME}'"
+    jlink --module-path ${JAVA_HOME}"/jmods;mlib" \
           --add-modules com.greetings \
           --output executable
 else


### PR DESCRIPTION
…C:\libs\Java\jdk-9 without \lib at the end