### PR TITLE
Reorganize resources

### DIFF
--- a/Java-9-Resources.md
+++ b/Java-9-Resources.md
@@ -1,47 +1,40 @@
 Java/JDK 9 Resources
 ====================
 
-- JDK9 EA Download
-  - http://jdk.java.net/9/
-  - http://jdk.java.net/jigsaw
+- [JDK9 EA Download](http://jdk.java.net/9/); or [with latest Jigsaw changes](http://jdk.java.net/jigsaw)
 
-- JDK 9 Installation
-  - https://docs.oracle.com/javase/9/install/overview-jdk-9-and-jre-9-installation.htm#JSJIG-GUID-8677A77F-231A-40F7-98B9-1FD0B48C346A
+- [JDK 9 Installation](https://docs.oracle.com/javase/9/install/overview-jdk-9-and-jre-9-installation.htm#JSJIG-GUID-8677A77F-231A-40F7-98B9-1FD0B48C346A)
 
-- JDK 9 Project page
-  - http://openjdk.java.net/projects/jdk9/
+- [JDK 9 Project page](http://openjdk.java.net/projects/jdk9/)
 
-- JDK 9 Jigsaw Project page
-  - http://openjdk.java.net/projects/jigsaw/
+- [JDK 9 Jigsaw Project page](http://openjdk.java.net/projects/jigsaw/)
 
 - JSRs involved
-	- 379: JavaTM SE 9 Release Contents (https://jcp.org/en/jsr/detail?id=379) - umbrella JSR for Java 9
-	- 376: Java Platform Module System (http://openjdk.java.net/projects/jigsaw/spec/) - specified some of the below JEPs
+	- [379](https://jcp.org/en/jsr/detail?id=379): JavaTM SE 9 Release Contents - umbrella JSR for Java 9
+	- [376](https://jcp.org/en/jsr/detail?id=376): [Java Platform Module System](http://openjdk.java.net/projects/jigsaw/spec/) - specified some of the below JEPs
 
 - JEPs involved
 	- Module system of the Java platform as specified by project Jigsaw JEPs covered:
-		- 200: The Modular JDK (http://openjdk.java.net/jeps/200)
-			- 201: Modular Source Code (http://openjdk.java.net/jeps/201)
-				- 220: Modular Run-Time Images (http://openjdk.java.net/jeps/220) (depends on [JEP 162]((http://openjdk.java.net/jeps/162)))
-			- 260: Encapsulate Most Internal APIs (http://openjdk.java.net/jeps/260) (no dependencies)
-			- 261: Module System (http://openjdk.java.net/jeps/261) (depends on [JEP 220](http://openjdk.java.net/jeps/220), related to [JEP 238](http://openjdk.java.net/jeps/238))
-			- 282: jlink: The Java Linker (http://openjdk.java.net/jeps/282) (replaces implementation of [JEP 220](http://openjdk.java.net/jeps/220))
-			- 275: Modular Java Application Packaging (http://openjdk.java.net/jeps/275)
-		- 222: jshell: The Java Shell (Read-Eval-Print Loop) (http://openjdk.java.net/jeps/222)
-		- 193: Variable Handles (http://openjdk.java.net/jeps/193)
-		- 110: HTTP 2 Client (http://openjdk.java.net/jeps/110)
-		- 238: Multi-Release JAR Files (http://openjdk.java.net/jeps/238)
-		- 158: Unified JVM Logging (http://openjdk.java.net/jeps/158)
+		- [200](http://openjdk.java.net/jeps/200): The Modular JDK
+			- [201](http://openjdk.java.net/jeps/201): Modular Source Code
+				- [220](http://openjdk.java.net/jeps/220): Modular Run-Time Images  (depends on [JEP 162](http://openjdk.java.net/jeps/162))
+			- [260](http://openjdk.java.net/jeps/260): Encapsulate Most Internal APIs (no dependencies)
+			- [261](http://openjdk.java.net/jeps/261): Module System (depends on [JEP 220](http://openjdk.java.net/jeps/220), related to [JEP 238](http://openjdk.java.net/jeps/238))
+			- [282](http://openjdk.java.net/jeps/282): jlink: The Java Linker (replaces implementation of [JEP 220](http://openjdk.java.net/jeps/220))
+			- [275](http://openjdk.java.net/jeps/275): Modular Java Application Packaging
+		- [222](http://openjdk.java.net/jeps/222): jshell: The Java Shell (Read-Eval-Print Loop)
+		- [193](http://openjdk.java.net/jeps/193): Variable Handles
+		- [110](http://openjdk.java.net/jeps/110): HTTP 2 Client
+		- [238](http://openjdk.java.net/jeps/238): Multi-Release JAR Files
+		- [158](http://openjdk.java.net/jeps/158): Unified JVM Logging
 		- G1 related JEPs (3 of them)
 		- JEPs related to a number of security improvements
 		- JEPs related to a number of platform improvements
-		- Many, many more JEPs (see http://openjdk.java.net/jeps/0)
+		- Many, many more JEPs (see [list of all JEPs](http://openjdk.java.net/jeps/0))
 
-- JDK 9 Outreach
-  - https://wiki.openjdk.java.net/display/Adoption/JDK+9+Outreach
+- [JDK 9 Outreach](https://wiki.openjdk.java.net/display/Adoption/JDK+9+Outreach)
 
-- JDK 9 Quality Outreach (we could use your help here)
-  - https://wiki.openjdk.java.net/display/quality/Quality+Outreach
+- [JDK 9 Quality Outreach](https://wiki.openjdk.java.net/display/quality/Quality+Outreach) (we could use your help here)
 
 - Java 9: REPL
 	- https://www.voxxed.com/blog/2016/10/just-enough-code-hacking-jdk
@@ -164,17 +157,12 @@ Java/JDK 9 Resources
      - Dependency / modularity visualisation
         - https://github.com/accso/java9-jigsaw-depvis
 
-- Java 9: Migration
-	- https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-7744EF96-5899-4FB2-B34E-86D49B2E89B6
+- [Java 9: Migration](https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-7744EF96-5899-4FB2-B34E-86D49B2E89B6)
 
-- Java 9: Tool reference
-	- https://docs.oracle.com/javase/9/tools/tools-and-command-reference.htm#JSWOR596
+- [Java 9: Tool reference](https://docs.oracle.com/javase/9/tools/tools-and-command-reference.htm#JSWOR596)
 
-- Java 9: JavaDoc (API documentation)
-	- http://download.java.net/java/jdk9/docs/api/overview-summary.html
+- [Java 9: JavaDoc](http://download.java.net/java/jdk9/docs/api/overview-summary.html) (API documentation)
 
-- Java 9: Developer Guides
-	- https://docs.oracle.com/javase/9/javase-docs.htm#
+- [Java 9: Developer Guides](https://docs.oracle.com/javase/9/javase-docs.htm#)
 
-- Java 9: Quick Start guide
-	- http://openjdk.java.net/projects/jigsaw/quick-start
+- [Java 9: Quick Start guide](http://openjdk.java.net/projects/jigsaw/quick-start)

--- a/Java-9-Resources.md
+++ b/Java-9-Resources.md
@@ -2,7 +2,8 @@ Java/JDK 9 Resources
 ====================
 
 - JDK9 EA Download
-  - https://jdk9.java.net/jigsaw/
+  - http://jdk.java.net/9/
+  - http://jdk.java.net/jigsaw
 
 - JDK 9 Installation
   - https://docs.oracle.com/javase/9/install/overview-jdk-9-and-jre-9-installation.htm#JSJIG-GUID-8677A77F-231A-40F7-98B9-1FD0B48C346A
@@ -14,6 +15,7 @@ Java/JDK 9 Resources
   - http://openjdk.java.net/projects/jigsaw/
 
 - JSRs involved
+	- 379: JavaTM SE 9 Release Contents (https://jcp.org/en/jsr/detail?id=379) - umbrella JSR for Java 9
 	- 376: Java Platform Module System (http://openjdk.java.net/projects/jigsaw/spec/) - specified some of the below JEPs
 
 - JEPs involved

--- a/Java-9-Resources.md
+++ b/Java-9-Resources.md
@@ -1,18 +1,18 @@
 Java/JDK 9 Resources
 ====================
 
-- JDK9 EA Download 
-  - https://jdk9.java.net/jigsaw/	
+- JDK9 EA Download
+  - https://jdk9.java.net/jigsaw/
 
 - JDK 9 Installation
   - https://docs.oracle.com/javase/9/install/overview-jdk-9-and-jre-9-installation.htm#JSJIG-GUID-8677A77F-231A-40F7-98B9-1FD0B48C346A
 
-- JDK 9 Project page 
+- JDK 9 Project page
   - http://openjdk.java.net/projects/jdk9/
 
 - JDK 9 Jigsaw Project page
   - http://openjdk.java.net/projects/jigsaw/
-    
+
 - JSRs involved
 	- 376: Java Platform Module System (http://openjdk.java.net/projects/jigsaw/spec/) - specified some of the below JEPs
 
@@ -50,7 +50,7 @@ Java/JDK 9 Resources
 - Java 9: Jigsaw
     - Project Jigsaw @ conferences (slides and video)
 	    - http://openjdk.java.net/projects/jigsaw/talks
-	
+
 	- Useful topics
 		- https://www.sitepoint.com/java-9-resources/?utm_source=Sociallymap&utm_medium=Sociallymap&utm_campaign=Sociallymap
 
@@ -58,7 +58,7 @@ Java/JDK 9 Resources
 		- https://www.voxxed.com/blog/interview/java-9-coming-nicolai-parlog/
 		- https://www.voxxed.com/blog/2016/03/13285/
 		- https://www.voxxed.com/blog/2014/09/preparing-for-java-the-modular-edition/
-		
+
 		- http://blog.codefx.org/java/dev/javaone-2015-prepare-for-jdk-9/
 			- [blog] http://blog.codefx.org/java/dev/javaone-2015-introduction-to-modular-development/
 			- [video] https://www.youtube.com/watch?v=eALw4P_0O4k - Introduction to Modular Development by Alan Bateman (3 months)
@@ -68,10 +68,10 @@ Java/JDK 9 Resources
 			- Prepare for JDK 9 by haocheng - JCConf 2016 R0 Day2-4
 				- https://www.youtube.com/watch?v=S91fn0dFTTY
 			- Simon Ritter - Preparing for JDK 9 with Zulu and OpenJDK
-				- https://www.youtube.com/watch?v=i9bnV0KKyAA 
+				- https://www.youtube.com/watch?v=i9bnV0KKyAA
 			- 180.Course Preview- Java 9 Modularity- First Look.mp4
 				- https://www.youtube.com/watch?v=0UD3KIwXwJw
-	
+
 	- New features
 		- Summary of features
 			- http://www.baeldung.com/new-java-9
@@ -80,7 +80,7 @@ Java/JDK 9 Resources
 
 		- https://www.voxxed.com/blog/2015/12/project-jigsaw-hands-on-guide
 		- https://www.voxxed.com/blog/2015/06/jumping-into-java-9-new-build-ready-to-test/
-		- https://www.voxxed.com/blog/2016/09/java-9-weak-modules/	
+		- https://www.voxxed.com/blog/2016/09/java-9-weak-modules/
 
 		- Java 9: Encapsulate Most Internal APIs
 			- https://www.voxxed.com/blog/2016/11/java-9-series-encapsulate-internal-apis/
@@ -146,7 +146,7 @@ Java/JDK 9 Resources
 	- Advanced Modular Development
 		- [blog] http://blog.codefx.org/java/dev/javaone-2015-advanced-modular-development/
 		- [video] https://www.youtube.com/watch?v=WJHjKMIrbD0 (5 months old)
-	
+
 		- http://blog.codefx.org/java/dev/javaone-2015-under-the-hood-of-project-jigsaw/%22
 		- https://www.voxxed.com/blog/presentation/presentation-java-9-make-way-for-modules/
 		- [video] https://www.youtube.com/watch?v=IA8FkrY0VFE - Modular Development with JDK 9
@@ -156,7 +156,7 @@ Java/JDK 9 Resources
 			- The Java Module System In Action (Nicolai Parlog, Germany)
 				- https://www.youtube.com/watch?v=0M72pH2rXwA
         - Refactoring legacy to modular apps (examples)
-            - Rabea Gransberger: https://github.com/rgra/java9-module-refactoring 
+            - Rabea Gransberger: https://github.com/rgra/java9-module-refactoring
             - Sander Mak & Paul Pakker: https://github.com/java9-modularity/java9-migration-demos
         - [blog] http://blog.joda.org/2017/04/java-9-modules-jpms-basics.html
      - Dependency / modularity visualisation

--- a/Java-9-Resources.md
+++ b/Java-9-Resources.md
@@ -1,168 +1,165 @@
-Java/JDK 9 Resources
-====================
+# Java/JDK 9 Resources
 
-- [JDK9 EA Download](http://jdk.java.net/9/); or [with latest Jigsaw changes](http://jdk.java.net/jigsaw)
+- [Early Access Download](http://jdk.java.net/9/); or [with latest Jigsaw changes](http://jdk.java.net/jigsaw)
+- [Installation Guide](https://docs.oracle.com/javase/9/install/overview-jdk-9-and-jre-9-installation.htm#JSJIG-GUID-8677A77F-231A-40F7-98B9-1FD0B48C346A)
 
-- [JDK 9 Installation](https://docs.oracle.com/javase/9/install/overview-jdk-9-and-jre-9-installation.htm#JSJIG-GUID-8677A77F-231A-40F7-98B9-1FD0B48C346A)
+## Oracle/OpenJDK Resources on Java 9
 
-- [JDK 9 Project page](http://openjdk.java.net/projects/jdk9/)
+- [What's New In JDK 9](https://docs.oracle.com/javase/9/whatsnew/toc.htm#JSNEW-GUID-C23AFD78-C777-460B-8ACE-58BE5EA681F6)
+- [Developer Guides](https://docs.oracle.com/javase/9/javase-docs.htm)
+- [Tool Reference](https://docs.oracle.com/javase/9/tools/tools-and-command-reference.htm#JSWOR596)
+- [Migration Guide](https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-7744EF96-5899-4FB2-B34E-86D49B2E89B6)
+- [JavaDoc](http://download.java.net/java/jdk9/docs/api/overview-summary.html) (API documentation)
+- [Project Jigsaw Quick Start Guide](http://openjdk.java.net/projects/jigsaw/quick-start)
+- [JDK 9 Outreach](https://wiki.openjdk.java.net/display/Adoption/JDK+9+Outreach) and [Quality Outreach](https://wiki.openjdk.java.net/display/quality/Quality+Outreach) (we could use your help here)
+- [List of all JEPs](http://openjdk.java.net/jeps/0)
 
-- [JDK 9 Jigsaw Project page](http://openjdk.java.net/projects/jigsaw/)
+***
 
-- JSRs involved
-	- [379](https://jcp.org/en/jsr/detail?id=379): JavaTM SE 9 Release Contents - umbrella JSR for Java 9
-	- [376](https://jcp.org/en/jsr/detail?id=376): [Java Platform Module System](http://openjdk.java.net/projects/jigsaw/spec/) - specified some of the below JEPs
+## Java 9
 
-- JEPs involved
-	- Module system of the Java platform as specified by project Jigsaw JEPs covered:
-		- [200](http://openjdk.java.net/jeps/200): The Modular JDK
-			- [201](http://openjdk.java.net/jeps/201): Modular Source Code
-				- [220](http://openjdk.java.net/jeps/220): Modular Run-Time Images  (depends on [JEP 162](http://openjdk.java.net/jeps/162))
-			- [260](http://openjdk.java.net/jeps/260): Encapsulate Most Internal APIs (no dependencies)
-			- [261](http://openjdk.java.net/jeps/261): Module System (depends on [JEP 220](http://openjdk.java.net/jeps/220), related to [JEP 238](http://openjdk.java.net/jeps/238))
-			- [282](http://openjdk.java.net/jeps/282): jlink: The Java Linker (replaces implementation of [JEP 220](http://openjdk.java.net/jeps/220))
-			- [275](http://openjdk.java.net/jeps/275): Modular Java Application Packaging
-		- [222](http://openjdk.java.net/jeps/222): jshell: The Java Shell (Read-Eval-Print Loop)
-		- [193](http://openjdk.java.net/jeps/193): Variable Handles
-		- [110](http://openjdk.java.net/jeps/110): HTTP 2 Client
-		- [238](http://openjdk.java.net/jeps/238): Multi-Release JAR Files
-		- [158](http://openjdk.java.net/jeps/158): Unified JVM Logging
-		- G1 related JEPs (3 of them)
-		- JEPs related to a number of security improvements
-		- JEPs related to a number of platform improvements
-		- Many, many more JEPs (see [list of all JEPs](http://openjdk.java.net/jeps/0))
+Official resources:
 
-- [JDK 9 Outreach](https://wiki.openjdk.java.net/display/Adoption/JDK+9+Outreach)
+- [JDK 9 Project Page](http://openjdk.java.net/projects/jdk9/); includes a list of JEPs targeted for Java 9
+- [JSR 379](https://jcp.org/en/jsr/detail?id=379): Java SE 9 Release Contents - umbrella JSR for Java 9
 
-- [JDK 9 Quality Outreach](https://wiki.openjdk.java.net/display/quality/Quality+Outreach) (we could use your help here)
+Community resources:
 
-- Java 9: REPL
-	- https://www.voxxed.com/blog/2016/10/just-enough-code-hacking-jdk
-	- https://www.voxxed.com/blog/2016/09/java-9-series-jshell/
-	- https://www.voxxed.com/blog/2015/04/what-the-upcoming-repl-will-mean-for-java-people/
-	- https://www.voxxed.com/blog/2015/07/a-sneak-peek-at-java-9-sleeper-feature-repl-and-jshell/
+- [Java 9 resources](https://blog.codefx.org/java/java-9-resources-talks-articles-blogs-books-courses/) (Nicolai Parlog)
+- [Ultimate Guide To Java 9](https://www.sitepoint.com/ultimate-guide-to-java-9/) (Nicolai Parlog)
+- [Java 9 New Features](http://www.baeldung.com/new-java-9) (Baeldung)
+- [Java 9 series: the JVM](https://www.voxxed.com/blog/2016/10/java-9-series-jvm/) (Katharine Beaumont)
 
-- Java 9: Jigsaw
-    - Project Jigsaw @ conferences (slides and video)
-	    - http://openjdk.java.net/projects/jigsaw/talks
+Talks and Interviews:
 
-	- Useful topics
-		- https://www.sitepoint.com/java-9-resources/?utm_source=Sociallymap&utm_medium=Sociallymap&utm_campaign=Sociallymap
+- [Java 9 is coming!](https://www.voxxed.com/blog/interview/java-9-coming-nicolai-parlog/) (Voxxed with Nicolai Parlog)
+- [Getting Ready for Java 9](https://www.voxxed.com/blog/2016/03/13285/) (Voxxed with Simon Ritter)
+- [Java 9 and Streams API](https://www.voxxed.com/blog/2017/02/java-9-streams-api/) (Voxxed with Simon Ritter)
+- [Preparing for JDK 9 with Zulu and OpenJDK](https://www.youtube.com/watch?v=i9bnV0KKyAA) (Simon Ritter)
+- [Prepare for JDK 9](https://www.youtube.com/watch?v=S91fn0dFTTY) (Haocheng)
 
-	- Preparing for JDK 9
-		- https://www.voxxed.com/blog/interview/java-9-coming-nicolai-parlog/
-		- https://www.voxxed.com/blog/2016/03/13285/
-		- https://www.voxxed.com/blog/2014/09/preparing-for-java-the-modular-edition/
+### Language Improvements
 
-		- http://blog.codefx.org/java/dev/javaone-2015-prepare-for-jdk-9/
-			- [blog] http://blog.codefx.org/java/dev/javaone-2015-introduction-to-modular-development/
-			- [video] https://www.youtube.com/watch?v=eALw4P_0O4k - Introduction to Modular Development by Alan Bateman (3 months)
-			- [video] https://www.youtube.com/watch?v=Ks7J_qQVR7Y - Project Jigsaw in JDK 9: Modularity Comes To Java - Simon Ritter (3 months old)
-			- Prepare JDK 9
-				- https://www.youtube.com/watch?v=eU8hCCjGSbE
-			- Prepare for JDK 9 by haocheng - JCConf 2016 R0 Day2-4
-				- https://www.youtube.com/watch?v=S91fn0dFTTY
-			- Simon Ritter - Preparing for JDK 9 with Zulu and OpenJDK
-				- https://www.youtube.com/watch?v=i9bnV0KKyAA
-			- 180.Course Preview- Java 9 Modularity- First Look.mp4
-				- https://www.youtube.com/watch?v=0UD3KIwXwJw
+[JEP 213](http://openjdk.java.net/jeps/213): Milling Project Coin
 
-	- New features
-		- Summary of features
-			- http://www.baeldung.com/new-java-9
-			- https://docs.oracle.com/javase/9/whatsnew/toc.htm#JSNEW-GUID-656B84C8-2498-4CD0-B20D-8C9AC633746B
-			- https://www.voxxed.com/blog/2015/07/the-features-project-jigsaw-brings-to-java-9/
+- [A New Try-with-resources Improvement in JDK 9](https://www.voxxed.com/blog/2015/01/new-try-resources-improvement-jdk-9/) (Mite Mitreski)
 
-		- https://www.voxxed.com/blog/2015/12/project-jigsaw-hands-on-guide
-		- https://www.voxxed.com/blog/2015/06/jumping-into-java-9-new-build-ready-to-test/
-		- https://www.voxxed.com/blog/2016/09/java-9-weak-modules/
+### Collection Factories
 
-		- Java 9: Encapsulate Most Internal APIs
-			- https://www.voxxed.com/blog/2016/11/java-9-series-encapsulate-internal-apis/
+[JEP 269](http://openjdk.java.net/jeps/269): Convenience Factory Methods for Collections
 
-		- Java 9: Multi-Release Jar
-			- https://www.voxxed.com/blog/2016/11/java-9-series-multi-release-jar-files/
+- [Java 9 series: Convenience Factory Methods for Collections](https://www.voxxed.com/blog/2017/01/java-9-series-factory-methods-collections/) (Katharine Beaumont)
 
-		- Java 9: Concurrency updates
-			- https://www.voxxed.com/blog/2016/10/java-9-series-concurrency-updates/
+### JShell
 
-		- Java 9: Variable Handles
-			- https://www.voxxed.com/blog/2016/11/java-9-series-variable-handles/
+[JEP 222](http://openjdk.java.net/jeps/222): jshell - The Java Shell (Read-Eval-Print Loop)
 
-		- Java 9: Http/2 Client
-			- https://www.voxxed.com/blog/2016/10/java-9-series-http2-client/
+- [What REPL will Mean for Java People](https://www.voxxed.com/blog/2015/04/what-the-upcoming-repl-will-mean-for-java-people/) (Lucy Carey)
+- [Java 9 series: JShell](https://www.voxxed.com/blog/2016/09/java-9-series-jshell/) (Katharine Beaumont)
 
-		- Java 9: Compact Strings
-			- https://www.voxxed.com/blog/2015/11/london-java-community-holds-strong-in-jcp-election/
+### Multi-Release JARs
 
-		- Java 9: Try-with-resources feature
-			- https://www.voxxed.com/blog/2015/01/new-try-resources-improvement-jdk-9/
+[JEP 238](http://openjdk.java.net/jeps/238): Multi-Release JAR Files
 
-		- Java 9: Compact profiles
-			- https://www.voxxed.com/blog/2014/12/jdeps-compact-profiles-java-modularity/
+- [Java 9 series: Multi-Release JAR Files](https://www.voxxed.com/blog/2016/11/java-9-series-multi-release-jar-files/) (Katharine Beaumont)
 
-		- Java 9: Streams
-			- https://www.voxxed.com/blog/2017/02/java-9-streams-api/
+### Reactive Streams aka Flow API And Other Concurrency Updates
 
-		- Java 9: Convenience Factory Methods
-			- https://www.voxxed.com/blog/2017/01/java-9-series-factory-methods-collections/
+[JEP 266](http://openjdk.java.net/jeps/266): More Concurrency Updates
 
-		- Java 9: Segmented Code Cache
-			- https://www.voxxed.com/blog/2016/11/java-9-series-segmented-code-cache/
+- [Java 9 series: Concurrency Updates](https://www.voxxed.com/blog/2016/10/java-9-series-concurrency-updates/) (Katharine Beaumont)
 
-		- Java 9: JVM
-			- https://www.voxxed.com/blog/2016/10/java-9-series-jvm/
+### Variable Handles
 
-		- Java 9: Unsafe
-			- https://www.voxxed.com/blog/2015/08/java-handlers-propose-encapulating-fix-for-unsafe-debacle/
-			- https://www.voxxed.com/blog/2015/07/will-removal-of-sun-misc-unsafe-trigger-javapocalypse/
+[JEP 193](http://openjdk.java.net/jeps/193): Variable Handles
 
-		- Java 9: Augment Use-Site…, Enums…, Lambda Leftovers
-			- https://www.voxxed.com/blog/2016/12/three-new-jeps/
+- [Java 9 series: Variable Handles](https://www.voxxed.com/blog/2016/11/java-9-series-variable-handles/) (Katharine Beaumont)
 
-		- Java 9: Panama updates
-			- https://www.voxxed.com/blog/2016/01/sailing-far-shores-project-panama-makes-progress/
+### HTTP/2 Client
 
-		- Java 9: AOT
-			- https://www.voxxed.com/blog/2016/10/native-ahead-time-compilation-java/
+[JEP 110](http://openjdk.java.net/jeps/110): HTTP/2 Client (Incubator)
 
-		- Java 9/10: var or val
-			- https://www.voxxed.com/blog/2016/09/var-comes-to-java/
+- [Java 9 series: HTTP/2 Client](https://www.voxxed.com/blog/2016/10/java-9-series-http2-client/) (Katharine Beaumont)
 
-	- Cons of Java 9 modularity (the other side of things)
-		- https://www.voxxed.com/blog/2015/12/will-there-be-module-hell/
-		- https://www.voxxed.com/blog/2015/05/will-java-9-mess-up-your-code
-		- https://www.voxxed.com/blog/2016/11/problem-modules-reflective-access/
-		- https://www.voxxed.com/blog/2016/11/issues-with-the-module-system/
-		- https://www.voxxed.com/blog/2015/05/will-java-9-mess-up-your-code/
-		- https://blog.plan99.net/is-jigsaw-good-or-is-it-wack-ec634d36dd6f
-		- https://developer.jboss.org/blogs/scott.stark/2017/04/14/critical-deficiencies-in-jigsawjsr-376-java-platform-module-system-ec-member-concerns?_sscc=t
+### Segmented Code Cache
 
-	- Advanced Modular Development
-		- [blog] http://blog.codefx.org/java/dev/javaone-2015-advanced-modular-development/
-		- [video] https://www.youtube.com/watch?v=WJHjKMIrbD0 (5 months old)
+[JEP 197](http://openjdk.java.net/jeps/197): Segmented Code Cache
 
-		- http://blog.codefx.org/java/dev/javaone-2015-under-the-hood-of-project-jigsaw/%22
-		- https://www.voxxed.com/blog/presentation/presentation-java-9-make-way-for-modules/
-		- [video] https://www.youtube.com/watch?v=IA8FkrY0VFE - Modular Development with JDK 9
-		- https://www.voxxed.com/blog/presentation/presentation-java-9-modularity-action/
-			- Java 9 Modularity in Action
-				- https://www.youtube.com/watch?v=CoXueufCdtY
-			- The Java Module System In Action (Nicolai Parlog, Germany)
-				- https://www.youtube.com/watch?v=0M72pH2rXwA
-        - Refactoring legacy to modular apps (examples)
-            - Rabea Gransberger: https://github.com/rgra/java9-module-refactoring
-            - Sander Mak & Paul Pakker: https://github.com/java9-modularity/java9-migration-demos
-        - [blog] http://blog.joda.org/2017/04/java-9-modules-jpms-basics.html
-     - Dependency / modularity visualisation
-        - https://github.com/accso/java9-jigsaw-depvis
+- [Java 9 series: Segmented Code Cache](https://www.voxxed.com/blog/2016/11/java-9-series-segmented-code-cache/) (Katharine Beaumont)
 
-- [Java 9: Migration](https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-7744EF96-5899-4FB2-B34E-86D49B2E89B6)
+### Ahead-of-Time Compilation
 
-- [Java 9: Tool reference](https://docs.oracle.com/javase/9/tools/tools-and-command-reference.htm#JSWOR596)
+[JEP 295](http://openjdk.java.net/jeps/295): Ahead-of-Time Compilation
 
-- [Java 9: JavaDoc](http://download.java.net/java/jdk9/docs/api/overview-summary.html) (API documentation)
+- [Native Ahead-of-Time Compilation in Java](https://www.voxxed.com/blog/2016/10/native-ahead-time-compilation-java/) (Mite Mitreski)
 
-- [Java 9: Developer Guides](https://docs.oracle.com/javase/9/javase-docs.htm#)
+### Misc
 
-- [Java 9: Quick Start guide](http://openjdk.java.net/projects/jigsaw/quick-start)
+- [JEP 158](http://openjdk.java.net/jeps/158): Unified JVM Logging
+- G1 related JEPs (3 of them)
+- JEPs related to a number of security improvements
+- JEPs related to a number of platform improvements
+
+***
+
+## Java Platform Module System
+
+- [JSR 376](https://jcp.org/en/jsr/detail?id=376): Java Platform Module System - specified some of the below JEPs
+- [Jigsaw Project Page](http://openjdk.java.net/projects/jigsaw/)
+- [Jigsaw Specification](http://openjdk.java.net/projects/jigsaw/spec/)
+
+### JEPs
+
+- [200](http://openjdk.java.net/jeps/200): The Modular JDK
+- [201](http://openjdk.java.net/jeps/201): Modular Source Code
+- [220](http://openjdk.java.net/jeps/220): Modular Run-Time Images  (depends on [JEP 162](http://openjdk.java.net/jeps/162))
+- [260](http://openjdk.java.net/jeps/260): Encapsulate Most Internal APIs (no dependencies)
+- [261](http://openjdk.java.net/jeps/261): Module System (depends on [JEP 220](http://openjdk.java.net/jeps/220), related to [JEP 238](http://openjdk.java.net/jeps/238))
+- [282](http://openjdk.java.net/jeps/282): jlink: The Java Linker (replaces implementation of [JEP 220](http://openjdk.java.net/jeps/220))
+- [275](http://openjdk.java.net/jeps/275): Modular Java Application Packaging
+
+### Talks And Interviews
+
+There is an [overview over all talks by the Jigsaw-team](http://openjdk.java.net/projects/jigsaw/talks).
+
+Series of blog posts on [CodeFX](http://codefx.org) summarizing talks by the Jigsaw team at JavaOne 2015:
+
+- [Prepare For JDK 9](https://blog.codefx.org/java/dev/javaone-2015-prepare-for-jdk-9/) (Alan Bateman)
+- [Introduction to Modular Development](http://blog.codefx.org/java/dev/javaone-2015-introduction-to-modular-development/) (Alan Bateman)
+- [Advanced Modular Development](https://blog.codefx.org/java/dev/javaone-2015-advanced-modular-development/) (Mark Reinhold, Alex Buckley, Alan Bateman)
+- [Under The Hood Of Project Jigsaw](https://blog.codefx.org/java/dev/javaone-2015-under-the-hood-of-project-jigsaw/) (Alex Buckley)
+
+Talks by the Jigsaw team at JavaOne 2016:
+
+- Prepare for JDK 9 (Alan Bateman) [[slides](prepare-for-jdk9-j1-2016.pdf), [video](https://www.youtube.com/watch?v=eU8hCCjGSbE)]
+- Introduction to Modular Development (Alan Bateman) [[slides](intro-modular-dev-j1-2016.pdf), [video](https://www.youtube.com/watch?v=2Hmrn_r-uJA)]
+- Advanced Modular Development (Alan Bateman, Alex Buckley) [[slides](adv-modular-dev-j1-2016.pdf), [video](https://www.youtube.com/watch?v=WWbw8u5jaaU)]
+- Project Jigsaw: Under the Hood (Alex Buckley) [[slides](jigsaw-under-the-hood-j1-2016.pdf), [video](https://www.youtube.com/watch?v=Vxfd3ehdAZc)]
+- Modules and Services (Alex Buckley) [[slides](modules-and-services-j1-2016.pdf), [video](https://www.youtube.com/watch?v=u8Hbdo-u-88)]
+- Project Jigsaw Hack Session (Alan Bateman, Mandy Chung, Mark Reinhold) [[video](https://www.youtube.com/watch?v=w4lLd-JOyRU)]
+
+Other talks:
+
+- [Project Jigsaw in JDK 9: Modularity Comes To Java](https://www.youtube.com/watch?v=Ks7J_qQVR7Y) (Simon Ritter)
+- [The Java Module System In Action](https://www.youtube.com/watch?v=0M72pH2rXwA) (Nicolai Parlog)
+- [Java 9 Modularity in Action](https://www.youtube.com/watch?v=CoXueufCdtY) (Sander Mak, Paul Bakker)
+
+### Articles
+
+- [Project Jigsaw Hands-On Guide](https://blog.codefx.org/java/dev/jigsaw-hands-on-guide/) (Nicolai Parlog)
+- [Java 9 series: Encapsulate Most Internal APIs](https://www.voxxed.com/blog/2016/11/java-9-series-encapsulate-internal-apis/) (Katharine Beaumont)
+- [Java 9 modules - JPMS basics](http://blog.joda.org/2017/04/java-9-modules-jpms-basics.html) (Stephen Colebourne)
+
+Downsides/hurdles of Java 9 modularity and Project Jigsaw:
+
+- [How Java 9 And Project Jigsaw May Break Your Code](https://blog.codefx.org/java/dev/how-java-9-and-project-jigsaw-may-break-your-code/) (Nicolai Parlog)
+- [Will There Be Module Hell?](https://blog.codefx.org/java/dev/will-there-be-module-hell/) (Nicolai Parlog)
+- [How do you solve a problem like Java 9 modules and reflective access?](https://www.voxxed.com/blog/2016/11/problem-modules-reflective-access/) (Katharine Beaumont)
+- [Issues with the Module System](https://www.voxxed.com/blog/2016/11/issues-with-the-module-system/) (Katharine Beaumont)
+- [Concerns Regarding Jigsaw(JSR-376, Java Platform Module System)](https://developer.jboss.org/blogs/scott.stark/2017/04/14/critical-deficiencies-in-jigsawjsr-376-java-platform-module-system-ec-member-concerns?_sscc=t) (JBoss Developer; [a reply](https://blog.plan99.net/is-jigsaw-good-or-is-it-wack-ec634d36dd6f))
+
+### Repositories
+
+- [rgra/java9-module-refactoring](https://github.com/rgra/java9-module-refactoring) (Rabea Gransberger)
+- [java9-modularity/java9-migration-demos](https://github.com/java9-modularity/java9-migration-demos) (Sander Mak, Paul Bakker)
+- [accso/java9-jigsaw-depvis](https://github.com/accso/java9-jigsaw-depvis) (Martin Lehmann, Kristine Schaal, Rüdiger Grammes)


### PR DESCRIPTION
As discussed on Twitter, here's my proposal for a reorganized resource list. Changes:

* Markdown links instead of blank URLs for better readability
* reorganization into a comprehensible structure
* attribution to authors/speakers

Besides from weeding out some outdated resource and replacing some links to syndicated posts with the original, the list items remain the same.