### PR TITLE
Example repositories

### DIFF
--- a/Java-9-Resources.md
+++ b/Java-9-Resources.md
@@ -180,6 +180,6 @@ Downsides/hurdles of Java 9 modularity and Project Jigsaw:
 - [java9-modularity/java9-migration-demos](https://github.com/java9-modularity/java9-migration-demos) (Sander Mak, Paul Bakker)
 - [https://github.com/java9-modularity/easytext](https://github.com/java9-modularity/java9-migration-demos) (Sander Mak, Paul Bakker), sample application from [O'Reilly's Java 9 Modularity book](http://shop.oreilly.com/product/0636920049494.do)
 - [accso/java9-jigsaw-depvis](https://github.com/accso/java9-jigsaw-depvis) (Martin Lehmann, Kristine Schaal, Rüdiger Grammes)
-- [codetojoy/WarO_Java_9_Gradle](https://github.com/codetojoy/WarO_Java_Gradle) (Michael Easter), example using Gradle 4.1M1
-- [codetojoy/WarO_Java_9_Maven](https://github.com/codetojoy/WarO_Java_Maven) (Michael Easter), example using Maven 3.5.0
+- [codetojoy/WarO_Java_9_Gradle](https://github.com/codetojoy/WarO_Java_9_Gradle) (Michael Easter), example using Gradle 4.1M1
+- [codetojoy/WarO_Java_9_Maven](https://github.com/codetojoy/WarO_Java_9_Maven) (Michael Easter), example using Maven 3.5.0
 - [codetojoy/easter_eggs_for_java_9](https://github.com/codetojoy/easter_eggs_for_java_9) (Michael Easter), various examples including jlink and patching

--- a/Java-9-Resources.md
+++ b/Java-9-Resources.md
@@ -180,6 +180,6 @@ Downsides/hurdles of Java 9 modularity and Project Jigsaw:
 - [java9-modularity/java9-migration-demos](https://github.com/java9-modularity/java9-migration-demos) (Sander Mak, Paul Bakker)
 - [https://github.com/java9-modularity/easytext](https://github.com/java9-modularity/java9-migration-demos) (Sander Mak, Paul Bakker), sample application from [O'Reilly's Java 9 Modularity book](http://shop.oreilly.com/product/0636920049494.do)
 - [accso/java9-jigsaw-depvis](https://github.com/accso/java9-jigsaw-depvis) (Martin Lehmann, Kristine Schaal, Rüdiger Grammes)
-- [codetojoy/WarO_Java_9_Gradle] (Michael Easter), example using Gradle 4.1M1
-- [codetojoy/WarO_Java_9_Maven] (Michael Easter), example using Maven 3.5.0
-- [codetojoy/easter_eggs_for_java_9] (Michael Easter), various examples including jlink and patching
+- [codetojoy/WarO_Java_9_Gradle](https://github.com/codetojoy/WarO_Java_Gradle) (Michael Easter), example using Gradle 4.1M1
+- [codetojoy/WarO_Java_9_Maven](https://github.com/codetojoy/WarO_Java_Maven) (Michael Easter), example using Maven 3.5.0
+- [codetojoy/easter_eggs_for_java_9](https://github.com/codetojoy/easter_eggs_for_java_9) (Michael Easter), various examples including jlink and patching

--- a/Java-9-Resources.md
+++ b/Java-9-Resources.md
@@ -180,3 +180,6 @@ Downsides/hurdles of Java 9 modularity and Project Jigsaw:
 - [java9-modularity/java9-migration-demos](https://github.com/java9-modularity/java9-migration-demos) (Sander Mak, Paul Bakker)
 - [https://github.com/java9-modularity/easytext](https://github.com/java9-modularity/java9-migration-demos) (Sander Mak, Paul Bakker), sample application from [O'Reilly's Java 9 Modularity book](http://shop.oreilly.com/product/0636920049494.do)
 - [accso/java9-jigsaw-depvis](https://github.com/accso/java9-jigsaw-depvis) (Martin Lehmann, Kristine Schaal, Rüdiger Grammes)
+- [codetojoy/WarO_Java_9_Gradle] (Michael Easter), example using Gradle 4.1M1
+- [codetojoy/WarO_Java_9_Maven] (Michael Easter), example using Maven 3.5.0
+- [codetojoy/easter_eggs_for_java_9] (Michael Easter), various examples including jlink and patching


### PR DESCRIPTION
A [recent issue](https://github.com/AdoptOpenJDK/jdk9-jigsaw/issues/49) mentioned examples with build tools.

This PR adds example repos to Java-9-Resources.md. One illustrates Gradle, one uses Maven, and another contains several examples including patching. 

Note: Gradle and Maven examples are _not complete_, in the sense that unit tests are an issue. But I plan to keep the repos current as the tooling improves.