### PR TITLE
Convert shell scripts to ant build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="JDK9 Jigsaw" default="check">
+  <!-- check minimum ant version required to be 1.9.9 -->
+  <target name="check-ant-version">
+    <property name="ant.version.required" value="1.9.9"/>
+    <antversion property="ant.current.version" />
+    <fail message="The current ant version, ${ant.current.version}, is too old. Please use ${ant.version.required} or above.">
+        <condition>
+            <not>
+                <antversion atleast="${ant.version.required}"/>
+            </not>
+        </condition>
+    </fail>
+  </target>
+
+  <target name="check-java-version">
+    <!-- look for a Class that is available only in jdk1.8 or above -->
+    <!-- core/exposed API class is better than an implementation class -->
+    <available property="jdk1.9+" classname="jdk.dynalink.DynamicLinker"/>
+
+    <!-- need jdk1.8 or above -->
+    <fail message="Unsupported Java version: ${ant.java.version}. Please use Java version 1.9 or greater." unless="jdk1.9+">
+    </fail>
+  </target>
+  <target name="check" depends="check-ant-version,check-java-version"/>
+</project>

--- a/session-1-jigsaw-intro/01_Greetings/build.xml
+++ b/session-1-jigsaw-intro/01_Greetings/build.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="01_Greettings" basedir="." default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="module.main" value="com.greetings.Main"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <echo>*** Compiling modules in 'mods/com.greetings' ***</echo>
+    <javac srcdir="${src.dir}"
+      destdir="${mods.dir}"
+      modulepath="${mods.dir}"
+      includeantruntime="false">
+    </javac>
+    <echo>*** Finished compiling modules into the 'mods/com.greetings' folder ***</echo>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="run" depends="compile">
+    <echo>*** Running 'com.greetings.Main' inside the 'mods' folder.</echo>
+    <java
+      modulepath="${mods.dir}"
+      module="${module.name}/${module.main}"
+      fork="true">
+    </java>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${mods.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/02_GreetingsWorld/build.xml
+++ b/session-1-jigsaw-intro/02_GreetingsWorld/build.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="02_GreettingsWorld" basedir="." default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="astro.dir" value="${src.dir}/org.astro"/>
+    <property name="astro.dist" value="${mods.dir}/org.astro"/>
+    <property name="greetings.dir" value="${src.dir}/com.greetings"/>
+    <property name="greetings.dist" value="${mods.dir}/com.greetings"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="module.main" value="com.greetings.Main"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+    <mkdir dir="${astro.dist}"/>
+    <mkdir dir="${greetings.dist}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <javac srcdir="${astro.dir}"
+      destdir="${astro.dist}"
+      includeantruntime="false">
+    </javac>
+
+    <javac srcdir="${greetings.dir}"
+      destdir="${greetings.dist}"
+      modulepath="${mods.dir}"
+      includeantruntime="false">
+    </javac>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="run" depends="compile">
+    <echo>*** Running 'com.greetings.Main' inside the 'mods' folder.</echo>
+    <java
+      modulepath="${mods.dir}"
+      module="${module.name}/${module.main}"
+      fork="true">
+    </java>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${mods.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/03_MultiModuleCompilation/build.xml
+++ b/session-1-jigsaw-intro/03_MultiModuleCompilation/build.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="03_MultiModuleCompilation" basedir="." default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="module.main" value="com.greetings.Main"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <javac destdir="${mods.dir}"
+      modulesourcepath="${src.dir}"
+      includeantruntime="false">
+    </javac>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="run" depends="compile">
+    <echo>*** Running 'com.greetings.Main' inside the 'mods' folder.</echo>
+    <java
+      modulepath="${mods.dir}"
+      module="${module.name}/${module.main}"
+      fork="true">
+    </java>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${mods.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/04_Packaging/build.xml
+++ b/session-1-jigsaw-intro/04_Packaging/build.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="04_Packaging" basedir="." default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="astro.dir" value="${mods.dir}/org.astro"/>
+    <property name="module.lib.dir" value="mlib"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="greetings.dir" value="${mods.dir}/${module.name}"/>
+    <property name="module.version" value="1.0"/>
+    <property name="module.main" value="${module.name}.Main"/>
+    <property name="astro.jar" value="${module.lib.dir}/org.astro@${module.version}.jar"/>
+    <property name="greetings.jar" value="${module.lib.dir}/${module.name}.jar"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+    <mkdir dir="${astro.dir}"/>
+    <mkdir dir="${greetings.dir}"/>
+    <mkdir dir="${module.lib.dir}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <javac destdir="${mods.dir}"
+      modulesourcepath="${src.dir}"
+      includeantruntime="false">
+    </javac>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="jar" depends="compile">
+    <jar
+      destfile="${astro.jar}"
+      basedir="${astro.dir}">
+      <manifest>
+        <attribute name="Module-Version" value="${module.version}"/>
+      </manifest>
+    </jar>
+
+    <!-- Doesn't work
+    <jar destfile="${greetings.jar}" basedir="${greetings.dir}">
+      <manifest>
+        <attribute name="Main-Class" value="${module.main}"/>
+      </manifest>
+    </jar>
+    -->
+    <exec executable="jar">
+      <arg line="--create --file ${greetings.jar}"/>
+      <arg line="--main-class ${module.main}"/>
+      <arg line="-C ${greetings.dir} ."/>
+    </exec>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${module.lib.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="describe" depends="jar">
+    <echo>*** Printing module description for org.astro as recorded in the module-info.class file in the package (jar) ***</echo>
+    <exec executable="jar">
+      <arg value="--verbose"/>
+      <arg value="--describe-module"/>
+      <arg value="--file=${astro.jar}"/>
+    </exec>
+
+    <echo>
+      *** Displaying contents of the module package org.astro@1.0 ***
+    </echo>
+    <exec executable="jar">
+      <arg value="--verbose"/>
+      <arg value="--list"/>
+      <arg value="--file=${astro.jar}"/>
+    </exec>
+
+    <echo>*** Printing module description for org.astro as recorded in the module-info.class file in the package (jar) ***</echo>
+    <exec executable="jar">
+      <arg value="--verbose"/>
+      <arg value="--describe-module"/>
+      <arg value="--file=${greetings.jar}"/>
+    </exec>
+
+    <echo>
+      *** Displaying contents of the module package com.greetings ***
+    </echo>
+    <exec executable="jar">
+      <arg value="--verbose"/>
+      <arg value="--list"/>
+      <arg value="--file=${greetings.jar}"/>
+    </exec>
+
+  </target>
+
+  <target name="run" depends="describe">
+    <echo>*** Running 'com.greetings.Main' from within the module package in the 'mlib' folder (running 'org.astro.World' from within the module package in the 'mlib' folder) ***</echo>
+    <java
+      modulepath="${module.lib.dir}"
+      module="${module.name}"
+      fork="true">
+    </java>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${mods.dir}"/>
+    <delete dir="${module.lib.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/05_Missing_exports/build.xml
+++ b/session-1-jigsaw-intro/05_Missing_exports/build.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="05_Missing_exports" basedir="." default="compile">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="astro.dir" value="${src.dir}/org.astro"/>
+    <property name="astro.dist" value="${mods.dir}/org.astro"/>
+    <property name="module.lib.dir" value="mlib"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="greetings.dir" value="${src.dir}/${module.name}"/>
+    <property name="greetings.dist" value="${mods.dir}/${module.name}"/>
+    <property name="module.version" value="1.0"/>
+    <property name="module.main" value="${module.name}.Main"/>
+    <property name="astro.jar" value="${module.lib.dir}/org.astro@${module.version}.jar"/>
+    <property name="greetings.jar" value="${module.lib.dir}/${module.name}.jar"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+    <mkdir dir="${astro.dir}"/>
+    <mkdir dir="${greetings.dir}"/>
+    <mkdir dir="${module.lib.dir}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <javac srcdir="${astro.dir}"
+      destdir="${astro.dist}"
+      includeantruntime="false">
+    </javac>
+
+    <echo>
+      *** Compiling modules in ${greetings.dir} (fails with an error due to module 'org.astro' not being visible) ***
+    </echo>
+
+    <javac srcdir="${greetings.dir}"
+      destdir="${greetings.dist}"
+      modulepath="${mods.dir}"
+      includeantruntime="false">
+    </javac>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${mods.dir}"/>
+    <delete dir="${module.lib.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/05_Missing_requires/build.xml
+++ b/session-1-jigsaw-intro/05_Missing_requires/build.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="05_Missing_requires" basedir="." default="compile">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="astro.dir" value="${src.dir}/org.astro"/>
+    <property name="astro.dist" value="${mods.dir}/org.astro"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="greetings.dir" value="${src.dir}/${module.name}"/>
+    <property name="greetings.dist" value="${mods.dir}/${module.name}"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+    <mkdir dir="${astro.dist}"/>
+    <mkdir dir="${greetings.dist}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <javac srcdir="${astro.dir}"
+      destdir="${astro.dist}"
+      includeantruntime="false">
+    </javac>
+
+    <echo>
+      *** Compiling modules in ${greetings.dir} (with 'requires' commented out) ***
+    </echo>
+    <javac srcdir="${greetings.dir}"
+      destdir="${greetings.dist}"
+      modulepath="${mods.dir}"
+      includeantruntime="false">
+    </javac>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${mods.dir}"/>
+    <delete dir="${module.lib.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/06_Services/build.xml
+++ b/session-1-jigsaw-intro/06_Services/build.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="06_Services" basedir="." default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="dist.dir" value="mods"/>
+    <property name="greetings.pkg" value="com.greetings"/>
+    <property name="greetings.src.dir" value="${src.dir}/${greetings.pkg}"/>
+    <property name="greetings.dist.dir" value="${dist.dir}/${greetings.pkg}"/>
+    <property name="greetings.main" value="${greetings.pkg}/${greetings.pkg}.Main"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${dist.dir}"/>
+    <mkdir dir="${greetings.dist.dir}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <javac destdir="${dist.dir}"
+      modulesourcepath="${src.dir}"
+      includeantruntime="false"/>
+
+    <echo>
+      *** Compiling modules in com.greetings - separately ***
+    </echo>
+    <javac destdir="${greetings.dist.dir}"
+      modulepath="${dist.dir}"
+      srcdir="${greetings.src.dir}"
+      includeantruntime="false"/>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${dist.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="run" depends="compile">
+    <echo>
+      *** Running 'com.greetings.Main' from within the mods folder (depends on 'com.socket' from within the mods folder) ***
+    </echo>
+    <java modulepath="${dist.dir}"
+      module="${greetings.main}"
+      fork="true"/>
+    <echo>
+      *** 'com.greetings.Main' imports and creates 'com.socket.NetworkSocket' ***
+      *** 'NetworkSocket.open()' returns a type of NetworkSocket with the help of a factory ***
+      *** The factory is a service provider that iterates through list of loaded services ***
+    </echo>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${dist.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/07_patch_ConcurrentHashMap/build.xml
+++ b/session-1-jigsaw-intro/07_patch_ConcurrentHashMap/build.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="07_patch_ConcurrentHashMap" basedir="." default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="patch.dir" value="${src.dir}/java.base"/>
+    <property name="dist.dir" value="mods"/>
+    <property name="patch.dist.dir" value="mypatches/java.base"/>
+    <property name="greetings.pkg" value="com.greetings"/>
+    <property name="greetings.src.dir" value="${src.dir}/${greetings.pkg}"/>
+    <property name="greetings.dist.dir" value="${dist.dir}/${greetings.pkg}"/>
+    <property name="greetings.main" value="${greetings.pkg}/${greetings.pkg}.Main"/>
+    <property name="compiler.override.option" value="--patch-module java.base=src" />
+    <property name="jvm.override.option" value="--patch-module java.base=${patch.dist.dir}"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${dist.dir}"/>
+    <mkdir dir="${greetings.dist.dir}"/>
+    <mkdir dir="${patch.dist.dir}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <echo>
+      *** Compiling a new version of ConcurrentHashMap ***
+    </echo>
+    <javac destdir="${patch.dist.dir}"
+      srcdir="${patch.dir}"
+      includeantruntime="false">
+      <compilerarg line="${compiler.override.option}"/>
+    </javac>
+
+    <echo>
+      *** Compiling Main class***
+    </echo>
+    <javac destdir="${greetings.dist.dir}"
+      modulepath="${dist.dir}"
+      srcdir="${greetings.src.dir}"
+      includeantruntime="false"/>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${patch.dist.dir}"/>
+    </antcall>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${dist.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="run" depends="compile">
+    <echo>
+      *** Running without the patch from within the mods folder. ***
+    </echo>
+    <java modulepath="${dist.dir}"
+      module="${greetings.main}"
+      fork="true"/>
+    <echo>
+      *** Running with the patch from within the mods folder. ***
+    </echo>
+
+    <java modulepath="${dist.dir}"
+      module="${greetings.main}"
+      fork="true">
+      <jvmarg line="${jvm.override.option}"/>
+    </java>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${dist.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/08_ModulesExportConflict/build.xml
+++ b/session-1-jigsaw-intro/08_ModulesExportConflict/build.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="08_ModulesExportConflict" basedir="." default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="astro.dir" value="${src.dir}/org.astro"/>
+    <property name="astro.dist" value="${mods.dir}/org.astro"/>
+    <property name="astro2.dir" value="${src.dir}/org.astro2"/>
+    <property name="astro2.dist" value="${mods.dir}/org.astro2"/>
+
+    <property name="greetings.dir" value="${src.dir}/com.greetings"/>
+    <property name="greetings.dist" value="${mods.dir}/com.greetings"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="module.main" value="com.greetings.Main"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+    <mkdir dir="${astro.dist}"/>
+    <mkdir dir="${astro2.dist}"/>
+    <mkdir dir="${greetings.dist}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <echo>
+      *** Compiling modules in ${astro.dir} ***
+    </echo>
+    <javac srcdir="${astro.dir}"
+      destdir="${astro.dist}"
+      includeantruntime="false">
+    </javac>
+
+    <echo>
+      *** Compiling modules in ${astro2.dir} ***
+    </echo>
+    <javac srcdir="${astro2.dir}"
+      destdir="${astro2.dist}"
+      includeantruntime="false">
+    </javac>
+
+    <echo>
+      *** Compiling modules in ${greetings.dir} ***
+    </echo>
+    <javac srcdir="${greetings.dir}"
+      destdir="${greetings.dist}"
+      modulepath="${mods.dir}"
+      includeantruntime="false">
+    </javac>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="run" depends="compile">
+    <echo>*** Running 'com.greetings.Main' inside the 'mods' folder.</echo>
+    <java
+      modulepath="${mods.dir}"
+      module="${module.name}/${module.main}"
+      fork="true">
+    </java>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${mods.dir}"/>
+  </target>
+</project>

--- a/session-1-jigsaw-intro/09_Automodules/build.xml
+++ b/session-1-jigsaw-intro/09_Automodules/build.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="09_Automodules" basedir="." default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="lib.dir" value="lib"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="module.dir" value="${src.dir}/${module.name}"/>
+    <property name="main.src.dir" value="${module.dir}/main/java"/>
+    <property name="test.src.dir" value="${module.dir}/test/java"/>
+    <property name="main.dist.dir" value="${mods.dir}/main/${module.name}"/>
+    <property name="test.dist.dir" value="${mods.dir}/test/${module.name}"/>
+    <property name="module.main" value="com.greetings.Main"/>
+    <property name="junit.jar" value="${lib.dir}/junit-4.12.jar"/>
+    <property name="hamcrest.jar" value="${lib.dir}/hamcrest-core-1.3.jar"/>
+    <property name="jvm.override.option" value="--add-modules ${module.name}"/>
+    <property name="junit.core" value="junit/org.junit.runner.JUnitCore"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+    <mkdir dir="${main.dist.dir}"/>
+    <mkdir dir="${test.dist.dir}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <echo>
+      *** Compiling main module in ${main.src.dir} ***
+    </echo>
+
+    <javac destdir="${main.dist.dir}"
+      modulepath="${lib.dir}"
+      srcdir="${src.dir}"
+      includeantruntime="false">
+    </javac>
+    <echo>
+      *** Compiling test module in ${test.src.dir} ***
+    </echo>
+    <javac destdir="${test.dist.dir}"
+      modulepath="${lib.dir}:${mods.dir}"
+      srcdir="${src.dir}"
+      includeantruntime="false">
+    </javac>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="run" depends="compile">
+    <echo>
+      *** Running from within the mods folder without arguments. ***
+    </echo>
+    <java
+      modulepath="${mods.dir}/main:${lib.dir}"
+      module="${module.name}/${module.main}"
+      fork="true">
+    </java>
+
+    <echo>
+      *** Running from within the mods folder with arguments. ***
+    </echo>
+    <java
+      modulepath="${mods.dir}/main:${lib.dir}"
+      module="${module.name}/${module.main}"
+      fork="true">
+      <arg line="Alice Bob Charlie"/>
+    </java>
+
+    <echo message="*** Running tests ***"/>
+    <java
+      modulepath="${mods.dir}/main:${lib.dir}"
+      module="${junit.core}"
+      fork="true">
+      <jvmarg line="${jvm.override.option}"/>
+      <arg value="com.greetings.GreetTest"/>
+    </java>
+  </target>
+
+  <target name="deps" depends="init">
+    <echo message="*** Module information for JUnit. ***"/>
+    <exec executable="jar">
+      <arg value="-d"/>
+      <arg line="--file=${junit.jar}"/>
+    </exec>
+    <echo message="*** Dependency information for JUnit. ***"/>
+    <exec executable="jdeps">
+      <arg value="-s"/>
+      <arg value="${junit.jar}"/>
+    </exec>
+
+    <echo message="*** Module information for Hamcrest. ***"/>
+    <exec executable="jar">
+      <arg value="-d"/>
+      <arg line="--file=${hamcrest.jar}"/>
+    </exec>
+    <echo message="*** Dependency information for Hamcrest. ***"/>
+    <exec executable="jdeps">
+      <arg value="-s"/>
+      <arg value="${hamcrest.jar}"/>
+    </exec>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${mods.dir}"/>
+  </target>
+</project>

--- a/session-2-jlink/01_JLink/build.xml
+++ b/session-2-jlink/01_JLink/build.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="01_JLink" default="run">
+  <target name="init">
+    <property name="src.dir" value="src"/>
+    <property name="mods.dir" value="mods"/>
+    <property name="lib.dir" value="mlib"/>
+    <property name="astro.dir" value="${src.dir}/org.astro"/>
+    <property name="astro.dist" value="${mods.dir}/org.astro"/>
+    <property name="module.name" value="com.greetings"/>
+    <property name="greetings.dir" value="${src.dir}/${module.name}"/>
+    <property name="greetings.dist" value="${mods.dir}/${module.name}"/>
+    <property name="astro.jar" value="${lib.dir}/org.astro@1.0.jar"/>
+    <property name="greetings.jar" value="${lib.dir}/com.greetings.jar"/>
+    <property name="module.main" value="com.greetings.Main"/>
+    <property name="exec.dir" value="executable"/>
+  </target>
+
+  <target name="prepare" depends="init">
+    <mkdir dir="${mods.dir}"/>
+    <mkdir dir="${lib.dir}"/>
+    <mkdir dir="${astro.dist}"/>
+    <mkdir dir="${greetings.dist}"/>
+  </target>
+
+  <target name="run-tree" depends="init">
+    <echo>*** Displaying the contents of the '${dir}' folder ***</echo>
+    <exec executable="tree">
+      <arg value="-fl"/>
+      <arg value="${dir}"/>
+    </exec>
+  </target>
+
+  <target name="compile" depends="prepare">
+    <antcall target="run-tree">
+      <param name="dir" value="${src.dir}"/>
+    </antcall>
+
+    <javac srcdir="${astro.dir}"
+      destdir="${astro.dist}"
+      includeantruntime="false">
+    </javac>
+
+    <javac srcdir="${greetings.dir}"
+      destdir="${greetings.dist}"
+      modulepath="${mods.dir}"
+      includeantruntime="false">
+    </javac>
+
+    <antcall target="run-tree">
+      <param name="dir" value="${mods.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="jar" depends="compile">
+    <jar basedir="${astro.dist}" destfile="${astro.jar}">
+      <manifest>
+        <attribute name="Module-Version" value="1.0"/>
+      </manifest>
+    </jar>
+
+    <!--
+    <jar basedir="${greetings.dist}" destfile="${greetings.jar}">
+      <manifest>
+        <attribute name="Main-Class" value="${module.main}"/>
+      </manifest>
+    </jar>
+    -->
+    <exec executable="jar">
+      <arg line="--create --file ${greetings.jar}"/>
+      <arg line="--main-class ${module.main}"/>
+      <arg line="-C ${greetings.dist} ."/>
+    </exec>
+    <antcall target="run-tree">
+      <param name="dir" value="${lib.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="link" depends="clean, jar">
+    <exec executable="jlink">
+      <arg line="--module-path ${java.home}/jmods:${lib.dir}"/>
+      <arg line="--add-modules ${module.name}"/>
+      <arg line="--output ${exec.dir}"/>
+    </exec>
+    <antcall target="run-tree">
+      <param name="dir" value="${exec.dir}"/>
+    </antcall>
+  </target>
+
+  <target name="run" depends="link">
+    <echo>
+      *** Running 'com.greetings.Main' from the module 'com.greetings' using the java in the 'executable' folder ***
+      *** The 'executable' folder is a distributable folder and we should be able to run it independent on another machine but for the same platform ***
+      *** Using the command-line action 'executable/bin/java --module com.greetings com.greetings.Main' ***
+      *** Please note that the distributable is platform specific ***
+    </echo>
+    <exec executable="${exec.dir}/bin/java">
+      <arg line="-jar ${greetings.jar}"/>
+      <arg value="${module.main}"/>
+    </exec>
+
+    <echo>
+      *** Running 'com.greetings.Main' from the via the main jar file in a separate 'mlib' folder using the java launcher in the 'executable' folder ***
+    </echo>
+    <exec executable="${exec.dir}/bin/java">
+      <arg line="--module ${module.name}"/>
+      <arg value="${module.main}"/>
+    </exec>
+  </target>
+
+  <target name="inspect" depends="link">
+    <echo>
+      *** Size (footprint) of the distributable JDK binary (executable folder) ***
+    </echo>
+    <exec executable="du">
+      <arg line="-sh ${exec.dir}"/>
+    </exec>
+    <echo>
+      *** The 'modules' file in the 'executable/lib' folder contains the compressed image of all the modules (JDK + your application modules) ***
+      *** We know this cause we can run 'jimage' on 'modules' and see its contents, below is some info on the image file ***
+    </echo>
+    <exec executable="jimage">
+      <arg line="info ${exec.dir}/lib/modules"/>
+    </exec>
+  </target>
+
+  <target name="clean" depends="init">
+    <delete dir="${lib.dir}"/>
+    <delete dir="${mods.dir}"/>
+    <delete dir="${exec.dir}"/>
+  </target>
+</project>


### PR DESCRIPTION
Some of the commands has to use the `exec` task, as there is no equivalent native ant task.