### PR TITLE
Added links to the respective setup pages to return to the README page

### DIFF
--- a/setupAndVerifyJDK.md
+++ b/setupAndVerifyJDK.md
@@ -141,3 +141,5 @@ If you don't like changing ```JAVA_HOME``` and ```PATH``` and you want to have a
 ```JAVA_HOME``` and ```PATH``` will use ```/usr/local/java/jdk``` forever.
 
 To change your local Java version, you only need to change the symbolic link.
+
+Now return to the [Download, install and verify JDK](./README.md#setup-all-platforms) section in the main [README.md](./README.md) file and continue with the rest of the steps.

--- a/setupTreeAndWget.md
+++ b/setupTreeAndWget.md
@@ -49,3 +49,4 @@ Please install the ```tree``` command before moving forward:
 
         Thanks Richard Kolb ([@rjdkolb](http://github.com/rjdkolb)) for your continued support in this area.
 
+Now return to the [Download and install tree and wget](./README.md#download-and-install-the-tree-and-wget-command) section in the main [README.md](./README.md) file and continue with the rest of the steps.


### PR DESCRIPTION
Links added to the bottom of the setupAndVerifyJDK and setupTreeAndWget markdown pages to return to the main README.md where we started from